### PR TITLE
Fixed gcc15 support

### DIFF
--- a/Tek40xx/tek_main.c
+++ b/Tek40xx/tek_main.c
@@ -43,7 +43,7 @@ typedef unsigned char CHAR;
 #undef main
 #endif
 
-FILE __iob_func[3] = { NULL, NULL, NULL };
+FILE __iob_func[3] = {{ 0, 0, 0 }};
 //FILE _iob[] = { NULL,NULL,NULL };
 //extern FILE * __cdecl __iob_func(void) { return _iob; }
 

--- a/Tek40xx/tek_video.h
+++ b/Tek40xx/tek_video.h
@@ -88,7 +88,7 @@ t_stat vid_setpixel(int ix,int iy,int level,uint32 color);
 uint32 vid_getpixel(int ix,int iy);
 t_stat vid_erase_win();
 void vid_drawline( int pX1, int pY1, int pX2, int pY2);
-int vid_setcursor();
+int vid_setcursor(uint32 mode);
 void vid_update_screen();
 void save_state(enum TekState state);
 int vid_map_key (int key);


### PR DESCRIPTION
```
gcc -c -o tek_main.o tek_main.c -DHAVE_LIBSDL -DSDL_MAIN_AVAILABLE `sdl2-config --cflags` -Ofast -Wall
tek_main.c:46:24: error: initialization of 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
   46 | FILE __iob_func[3] = { NULL, NULL, NULL };
      |                        ^~~~
tek_main.c:46:24: note: (near initialization for '__iob_func[0]._flags')
tek_main.c:46:22: warning: missing braces around initializer [-Wmissing-braces]
   46 | FILE __iob_func[3] = { NULL, NULL, NULL };
      |                      ^
```
```
gcc -c -o tek_main.o tek_main.c -DHAVE_LIBSDL -DSDL_MAIN_AVAILABLE `sdl2-config --cflags` -Ofast -Wall
tek_main.c:475:5: error: conflicting types for 'vid_setcursor'; have 'int(uint32)' {aka 'int(unsigned int)'}
  475 | int vid_setcursor(uint32 mode)
      |     ^~~~~~~~~~~~~
In file included from tek_main.c:31:
tek_video.h:91:5: note: previous declaration of 'vid_setcursor' with type 'int(void)'
   91 | int vid_setcursor();
      |     ^~~~~~~~~~~~~
